### PR TITLE
Fix isValid/validate naming in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,8 +53,8 @@ SSN.parse("2 55 08 14 168 025 38")
 }
 */
 
-SSN.isValid("2 55 08 14 168 025 12") // false
-SSN.isValid("2 55 08 14 168 025 38") // true
+SSN.validate("2 55 08 14 168 025 12") // false
+SSN.validate("2 55 08 14 168 025 38") // true
 SSN.getControlKey("2 55 08 14 168 025") // "38"
 SSN.make({ gender: 1, month: 5, year: 78, place: "99330", rank: 108 }) // "178059933010817"
 ```
@@ -64,7 +64,7 @@ SSN.make({ gender: 1, month: 5, year: 78, place: "99330", rank: 108 }) // "17805
 | Method | arguments | returned value | throws |
 | ------ | --------- | -------------- | ------ |
 | `parse` | `ssn: string \| number` : You may provide your ssn in various formats : a number with 15 digits, a string, with or without spaces, or any other delimiting character | an object containing information about the ssn owner | will throw if ssn is not correctly formated or if control key does not match. Will not throw if information provided does not make sense, information will simply be marked as "unknown". Eg: `parse("0 ...").gender = { unknown: true }` |
-| `isValid` | `ssn: string \| number` | `boolean` (this is only a convenience function, it calls `parse` under the hood in a try catch block) | never |
+| `validate` | `ssn: string \| number` | `boolean` (this is only a convenience function, it calls `parse` under the hood in a try catch block) | never |
 | `getControlKey` | `partialSSN: string \| number` : The first 13 characters of the ssn | `string` : the control key (2 digits between "01" and "97") | will throw if ssn is not correctly formated |
 | `make` | `params: { gender: string? \| number?, month: string? \| number?, year: string? \| number?, place: string? \| number?, rank: string? \| number?, controlKey: string? \| number? }` | `string` Mostly useful for tests, this function creates an SSN with the given params. If controlKey is not provided it is auto filled with a valid value. All named parameters of the function are optionnal. | |
 


### PR DESCRIPTION
`validate` was incorrectly called `isValid` in the README. This fix the documentation issue