### PR TITLE
refactor(format): export format to be used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import getControlKey from "./getControlKey"
 import parse from "./parse"
 import make from "./makeSSN"
+import format from "./format"
 
 export { getControlKey, parse, make }
 export const validate = ssn => {
@@ -17,4 +18,5 @@ export default {
   parse,
   validate,
   make,
+  format,
 }


### PR DESCRIPTION
I imported then exported the format function.
It allows the use of this method with the package.